### PR TITLE
feat: add interactive file picker for selective copying (Select & Copy)

### DIFF
--- a/media/filePicker.html
+++ b/media/filePicker.html
@@ -1,0 +1,625 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Select &amp; Copy (Copy4AI)</title>
+  <style>
+    :root {
+      --bg: var(--vscode-editor-background, #1e1e1e);
+      --fg: var(--vscode-editor-foreground, #cccccc);
+      --accent: var(--vscode-button-background, #0e639c);
+      --accent-hover: var(--vscode-button-hoverBackground, #1177bb);
+      --border: var(--vscode-panel-border, #444);
+      --hover-bg: var(--vscode-list-hoverBackground, #2a2d2e);
+      --input-bg: var(--vscode-input-background, #3c3c3c);
+      --secondary-btn-bg: var(--vscode-button-secondaryBackground, #3a3d41);
+      --secondary-btn-fg: var(--vscode-button-secondaryForeground, #cccccc);
+      --modal-bg: var(--vscode-editorWidget-background, #252526);
+      --modal-border: var(--vscode-editorWidget-border, #555);
+      --shadow: rgba(0, 0, 0, 0.5);
+      --ignored-opacity: 0.45;
+      --cb-border: #888;
+    }
+
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: var(--vscode-font-family, system-ui, sans-serif);
+      font-size: var(--vscode-font-size, 13px);
+      background: rgba(0, 0, 0, 0.4);
+      color: var(--fg);
+      display: flex;
+      align-items: flex-start;
+      justify-content: flex-start;
+      height: 100vh;
+      overflow: hidden;
+      padding-top: 16vh;
+      padding-left: 28vw;
+    }
+
+    .modal {
+      background: var(--modal-bg);
+      border: 1px solid var(--modal-border);
+      border-radius: 8px;
+      box-shadow: 0 8px 32px var(--shadow);
+      width: 540px;
+      max-width: 90vw;
+      max-height: 65vh;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .header {
+      padding: 14px 16px 10px;
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+
+    .header-top {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 8px;
+    }
+
+    .header h2 {
+      font-size: 13px;
+      font-weight: 600;
+    }
+
+    .toolbar {
+      display: flex;
+      gap: 4px;
+    }
+
+    .search-box {
+      width: 100%;
+      padding: 5px 10px;
+      background: var(--input-bg);
+      color: var(--fg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      outline: none;
+      font-size: 12px;
+      margin-bottom: 8px;
+    }
+
+    .search-box:focus {
+      border-color: var(--accent);
+    }
+
+    .toggle-row {
+      display: flex;
+      gap: 14px;
+      font-size: 11px;
+    }
+
+    .toggle-row label {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      cursor: pointer;
+      user-select: none;
+    }
+
+    .toggle-row input[type="checkbox"] {
+      display: none;
+    }
+
+    .toggle-cb {
+      width: 14px;
+      height: 14px;
+      border: 1.5px solid var(--cb-border);
+      border-radius: 3px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      background: transparent;
+      transition: all 0.15s;
+    }
+
+    .toggle-row input[type="checkbox"]:checked+.toggle-cb {
+      background: var(--accent);
+      border-color: var(--accent);
+    }
+
+    .toggle-row input[type="checkbox"]:checked+.toggle-cb::after {
+      content: "✓";
+      color: #fff;
+      font-size: 10px;
+      font-weight: bold;
+      line-height: 1;
+    }
+
+    .tree-container {
+      flex: 1;
+      overflow-y: auto;
+      padding: 4px 0;
+      min-height: 0;
+    }
+
+    .tree-node {
+      user-select: none;
+    }
+
+    .tree-row {
+      display: flex;
+      align-items: center;
+      padding: 2px 8px;
+      cursor: pointer;
+      gap: 4px;
+      height: 24px;
+    }
+
+    .tree-row:hover {
+      background: var(--hover-bg);
+    }
+
+    .tree-row.ignored {
+      opacity: var(--ignored-opacity);
+    }
+
+    .indent {
+      flex-shrink: 0;
+    }
+
+    .toggle {
+      width: 16px;
+      height: 16px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      font-size: 10px;
+      opacity: 0.7;
+    }
+
+    .toggle.collapsed::before {
+      content: "▶";
+    }
+
+    .toggle.expanded::before {
+      content: "▼";
+    }
+
+    .toggle.leaf {
+      visibility: hidden;
+    }
+
+    .cb {
+      width: 16px;
+      height: 16px;
+      border: 1.5px solid var(--cb-border);
+      border-radius: 3px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+      cursor: pointer;
+      background: transparent;
+      transition: all 0.12s;
+    }
+
+    .cb.unchecked {
+      background: transparent;
+      border-color: var(--cb-border);
+    }
+
+    .cb.checked {
+      background: var(--accent);
+      border-color: var(--accent);
+    }
+
+    .cb.checked::after {
+      content: "✓";
+      color: #fff;
+      font-size: 11px;
+      font-weight: bold;
+      line-height: 1;
+    }
+
+    .cb.partial {
+      background: var(--accent);
+      border-color: var(--accent);
+    }
+
+    .cb.partial::after {
+      content: "−";
+      color: #fff;
+      font-size: 14px;
+      font-weight: bold;
+      line-height: 1;
+    }
+
+    .icon {
+      flex-shrink: 0;
+      margin-right: 4px;
+      font-size: 14px;
+    }
+
+    .name {
+      font-size: 13px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .name.folder-name {
+      font-weight: 500;
+    }
+
+    .children {
+      display: block;
+    }
+
+    .children.collapsed {
+      display: none;
+    }
+
+    .footer {
+      padding: 10px 16px;
+      border-top: 1px solid var(--border);
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-shrink: 0;
+    }
+
+    .footer-stats {
+      font-size: 12px;
+      opacity: 0.8;
+    }
+
+    .btn-group {
+      display: flex;
+      gap: 8px;
+    }
+
+    button {
+      padding: 6px 14px;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 12px;
+      font-weight: 500;
+      transition: background 0.15s;
+    }
+
+    .btn-primary {
+      background: var(--accent);
+      color: #fff;
+    }
+
+    .btn-primary:hover {
+      background: var(--accent-hover);
+    }
+
+    .btn-secondary {
+      background: var(--secondary-btn-bg);
+      color: var(--secondary-btn-fg);
+    }
+
+    .btn-secondary:hover {
+      opacity: 0.85;
+    }
+
+    .tool-btn {
+      padding: 3px 8px;
+      font-size: 11px;
+      border-radius: 3px;
+      background: var(--secondary-btn-bg);
+      color: var(--secondary-btn-fg);
+    }
+
+    .tool-btn:hover {
+      opacity: 0.85;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="modal">
+    <div class="header">
+      <div class="header-top">
+        <h2 id="title">Select &amp; Copy (Copy4AI)</h2>
+        <div class="toolbar">
+          <button class="tool-btn" id="selectAll">Select All</button>
+          <button class="tool-btn" id="deselectAll">Deselect All</button>
+          <button class="tool-btn" id="expandAllBtn">Expand</button>
+          <button class="tool-btn" id="collapseAllBtn">Collapse</button>
+        </div>
+      </div>
+      <input type="text" class="search-box" id="search" placeholder="Filter files..." />
+      <div class="toggle-row">
+        <label title="Show files normally hidden by .gitignore rules">
+          <input type="checkbox" id="toggleGitignore" />
+          <span class="toggle-cb"></span>
+          Show .gitignore'd files
+        </label>
+        <label title="Show dot files (.env, .git, etc.)">
+          <input type="checkbox" id="toggleDotfiles" />
+          <span class="toggle-cb"></span>
+          Show dot files
+        </label>
+      </div>
+    </div>
+
+    <div class="tree-container" id="tree"></div>
+
+    <div class="footer">
+      <div class="footer-stats" id="footerStats">0 files selected</div>
+      <div class="btn-group">
+        <button class="btn-secondary" id="cancelBtn">Cancel</button>
+        <button class="btn-primary" id="copyBtn">Copy for AI</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const vscode = acquireVsCodeApi();
+
+    let treeData = [];
+    let selectedPaths = new Set();
+    let allFilePaths = [];
+    let expandedFolders = new Set();
+    let allFolderPaths = [];
+
+    window.addEventListener("message", (e) => {
+      const msg = e.data;
+      if (msg.command === "loadTree") {
+        treeData = msg.tree;
+        document.getElementById("title").textContent =
+          "Select & Copy — " + msg.folderName;
+
+        if (msg.preserveSelection && Array.isArray(msg.preserveSelection)) {
+          initializeTree(msg.preserveSelection);
+        } else {
+          initializeTree(msg.defaultSelected || []);
+        }
+      }
+    });
+
+    vscode.postMessage({ command: "ready" });
+
+    function initializeTree(selected) {
+      allFilePaths = [];
+      allFolderPaths = [];
+      selectedPaths.clear();
+      expandedFolders.clear();
+
+      collectAllEntries(treeData);
+
+      for (const p of selected) {
+        if (allFilePaths.includes(p)) {
+          selectedPaths.add(p);
+        }
+      }
+
+      // Expand first level by default
+      treeData.forEach((n) => {
+        if (n.type === "folder") expandedFolders.add(n.relativePath);
+      });
+
+      render();
+    }
+
+    function collectAllEntries(nodes) {
+      for (const n of nodes) {
+        if (n.type === "file") {
+          allFilePaths.push(n.relativePath);
+        } else if (n.type === "folder") {
+          allFolderPaths.push(n.relativePath);
+          if (n.children) collectAllEntries(n.children);
+        }
+      }
+    }
+
+    function getFolderState(node) {
+      const files = getDescendantFiles(node);
+      if (files.length === 0) return "unchecked";
+      const sel = files.filter((f) => selectedPaths.has(f));
+      if (sel.length === 0) return "unchecked";
+      if (sel.length === files.length) return "checked";
+      return "partial";
+    }
+
+    function getDescendantFiles(node) {
+      if (node.type === "file") return [node.relativePath];
+      const files = [];
+      if (node.children) {
+        for (const c of node.children) files.push(...getDescendantFiles(c));
+      }
+      return files;
+    }
+
+    function toggleNode(node) {
+      if (node.type === "file") {
+        if (selectedPaths.has(node.relativePath)) {
+          selectedPaths.delete(node.relativePath);
+        } else {
+          selectedPaths.add(node.relativePath);
+        }
+      } else {
+        const files = getDescendantFiles(node);
+        const state = getFolderState(node);
+        if (state === "checked") {
+          files.forEach((f) => selectedPaths.delete(f));
+        } else {
+          files.forEach((f) => selectedPaths.add(f));
+        }
+      }
+      render();
+    }
+
+    function toggleExpand(p) {
+      if (expandedFolders.has(p)) {
+        expandedFolders.delete(p);
+      } else {
+        expandedFolders.add(p);
+      }
+      render();
+    }
+
+    function render() {
+      const searchTerm = document.getElementById("search").value.toLowerCase();
+      const container = document.getElementById("tree");
+      container.innerHTML = "";
+      renderNodes(treeData, container, 0, searchTerm);
+      updateStats();
+    }
+
+    function renderNodes(nodes, parent, depth, searchTerm) {
+      for (const node of nodes) {
+        if (searchTerm && !matchesSearch(node, searchTerm)) continue;
+
+        const el = document.createElement("div");
+        el.className = "tree-node";
+
+        const row = document.createElement("div");
+        row.className = "tree-row" + (node.ignored ? " ignored" : "");
+
+        const indent = document.createElement("span");
+        indent.className = "indent";
+        indent.style.width = depth * 16 + "px";
+        row.appendChild(indent);
+
+        const toggle = document.createElement("span");
+        if (node.type === "folder") {
+          const expanded = expandedFolders.has(node.relativePath);
+          toggle.className = "toggle " + (expanded ? "expanded" : "collapsed");
+          toggle.addEventListener("click", (e) => {
+            e.stopPropagation();
+            toggleExpand(node.relativePath);
+          });
+        } else {
+          toggle.className = "toggle leaf";
+        }
+        row.appendChild(toggle);
+
+        const cb = document.createElement("span");
+        let cbState;
+        if (node.type === "file") {
+          cbState = selectedPaths.has(node.relativePath) ? "checked" : "unchecked";
+        } else {
+          cbState = getFolderState(node);
+        }
+        cb.className = "cb " + cbState;
+        cb.addEventListener("click", (e) => {
+          e.stopPropagation();
+          toggleNode(node);
+        });
+        row.appendChild(cb);
+
+        const icon = document.createElement("span");
+        icon.className = "icon";
+        icon.textContent = node.type === "folder" ? "📁" : "📄";
+        row.appendChild(icon);
+
+        const name = document.createElement("span");
+        name.className = "name" + (node.type === "folder" ? " folder-name" : "");
+        name.textContent = node.name;
+        name.title = node.relativePath + (node.ignored ? " (ignored)" : "");
+        row.appendChild(name);
+
+        row.addEventListener("click", () => {
+          if (node.type === "folder") {
+            toggleExpand(node.relativePath);
+          } else {
+            toggleNode(node);
+          }
+        });
+
+        el.appendChild(row);
+
+        if (node.type === "folder" && node.children) {
+          const childContainer = document.createElement("div");
+          const expanded = expandedFolders.has(node.relativePath);
+          childContainer.className = "children" + (expanded ? "" : " collapsed");
+          renderNodes(node.children, childContainer, depth + 1, searchTerm);
+          el.appendChild(childContainer);
+        }
+
+        parent.appendChild(el);
+      }
+    }
+
+    function matchesSearch(node, term) {
+      if (node.name.toLowerCase().includes(term)) return true;
+      if (node.relativePath.toLowerCase().includes(term)) return true;
+      if (node.children) return node.children.some((c) => matchesSearch(c, term));
+      return false;
+    }
+
+    function updateStats() {
+      document.getElementById("footerStats").textContent =
+        selectedPaths.size + " / " + allFilePaths.length + " files selected";
+    }
+
+    // ── Toolbar buttons ────────────────────────
+    document.getElementById("selectAll").addEventListener("click", () => {
+      allFilePaths.forEach((p) => selectedPaths.add(p));
+      render();
+    });
+
+    document.getElementById("deselectAll").addEventListener("click", () => {
+      selectedPaths.clear();
+      render();
+    });
+
+    document.getElementById("expandAllBtn").addEventListener("click", () => {
+      allFolderPaths.forEach((p) => expandedFolders.add(p));
+      render();
+    });
+
+    document.getElementById("collapseAllBtn").addEventListener("click", () => {
+      expandedFolders.clear();
+      render();
+    });
+
+    document.getElementById("search").addEventListener("input", () => {
+      render();
+    });
+
+    // ── Setting toggles ───────────────────────
+    document.getElementById("toggleGitignore").addEventListener("change", () => {
+      requestTreeRefresh();
+    });
+
+    document.getElementById("toggleDotfiles").addEventListener("change", () => {
+      requestTreeRefresh();
+    });
+
+    function requestTreeRefresh() {
+      const showGitIgnored = document.getElementById("toggleGitignore").checked;
+      const showDotFiles = document.getElementById("toggleDotfiles").checked;
+      vscode.postMessage({
+        command: "refreshTree",
+        showGitIgnored: showGitIgnored,
+        showDotFiles: showDotFiles,
+        currentSelection: Array.from(selectedPaths),
+      });
+    }
+
+    // ── Action buttons ─────────────────────────
+    document.getElementById("copyBtn").addEventListener("click", () => {
+      vscode.postMessage({
+        command: "copy",
+        selectedPaths: Array.from(selectedPaths),
+      });
+    });
+
+    document.getElementById("cancelBtn").addEventListener("click", () => {
+      vscode.postMessage({ command: "cancel" });
+    });
+  </script>
+</body>
+
+</html>

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   ],
   "preview": false,
   "pricing": "Free",
-  
   "main": "./out/extension.js",
   "activationEvents": [],
   "contributes": {
@@ -63,6 +62,10 @@
       {
         "command": "snapsource.toggleDotFiles",
         "title": "Toggle Dot Files Inclusion (Copy4AI)"
+      },
+      {
+        "command": "snapsource.selectAndCopy",
+        "title": "Select & Copy (Copy4AI)"
       }
     ],
     "menus": {
@@ -80,6 +83,10 @@
         },
         {
           "command": "snapsource.toggleDotFiles"
+        },
+        {
+          "command": "snapsource.selectAndCopy",
+          "when": "false"
         }
       ],
       "explorer/context": [
@@ -91,6 +98,11 @@
         {
           "command": "snapsource.copyProjectStructure",
           "group": "copy4ai@2"
+        },
+        {
+          "command": "snapsource.selectAndCopy",
+          "group": "copy4ai@3",
+          "when": "explorerResourceIsFolder"
         }
       ],
       "editor/context": [
@@ -123,13 +135,17 @@
             "properties": {
               "paths": {
                 "type": "array",
-                "items": { "type": "string" },
+                "items": {
+                  "type": "string"
+                },
                 "description": "Absolute paths relative to workspace root to exclude (e.g., 'src/config')",
                 "default": []
               },
               "patterns": {
                 "type": "array",
-                "items": { "type": "string" },
+                "items": {
+                  "type": "string"
+                },
                 "description": "Glob patterns to exclude (e.g., '*.tmp', 'build/**')",
                 "default": [
                   "node_modules",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,9 +9,11 @@ import { ProjectTreeGenerator } from './utils/projectTree';
 import { OutputFormatter } from './utils/formatters';
 import { IgnoreUtils } from './utils/ignoreUtils';
 import { TokenCounter } from './utils/tokenCounter';
+import { FilePickerPanel } from './filePickerPanel';
+
 
 export class Copy4AIService {
-    
+
     public static async copyToClipboard(
         uri?: vscode.Uri,
         uris?: ReadonlyArray<vscode.Uri>,
@@ -24,36 +26,36 @@ export class Copy4AIService {
         }, async (progress: ProgressReporter, token: CancellationToken) => {
             try {
                 progress.report({ increment: 0, message: "Initializing..." });
-                
+
                 const config = ConfigurationService.getConfiguration();
                 const excludeConfig = ConfigurationService.getExcludeConfig();
-                
+
                 // Options override global configuration for command-specific behavior
                 // This allows different commands to use different settings without changing user preferences
-                const includeProjectTree = options.projectTreeOnly ? true : 
-                                         (options.includeProjectTree !== undefined ? 
-                                         options.includeProjectTree : 
-                                         config.includeProjectTree);
-                
+                const includeProjectTree = options.projectTreeOnly ? true :
+                    (options.includeProjectTree !== undefined ?
+                        options.includeProjectTree :
+                        config.includeProjectTree);
+
                 const itemsToProcess = uris && uris.length > 0 ? uris : (uri ? [uri] : []);
-                
+
                 if (itemsToProcess.length === 0) {
                     throw new Error('No files or folders selected');
                 }
-                
+
                 progress.report({ increment: 10, message: "Setting up file filters..." });
-                
+
                 const workspaceFolder = vscode.workspace.getWorkspaceFolder(itemsToProcess[0]);
                 if (!workspaceFolder) {
                     throw new Error('No workspace folder found');
                 }
-                
+
                 const ig = IgnoreUtils.createIgnoreInstance(excludeConfig.patterns, config.ignoreDotFiles);
-                
+
                 if (config.ignoreGitIgnore) {
                     await IgnoreUtils.addGitIgnoreRules(workspaceFolder.uri.fsPath, ig);
                 }
-                
+
                 const isExcludedByAbsolutePath = IgnoreUtils.createAbsolutePathExclusionFn(
                     workspaceFolder.uri.fsPath,
                     excludeConfig.paths
@@ -63,10 +65,10 @@ export class Copy4AIService {
                     workspaceFolder.uri.fsPath,
                     config.excludeContentPatterns
                 );
-                
+
                 let projectRootPath = workspaceFolder.uri.fsPath;
                 let projectRootName = '';
-                
+
                 // Allow using selected folder as root for more focused project views
                 // Useful when working with large monorepos or when sharing specific subsections
                 if (options.useSelectedFolderAsRoot && itemsToProcess[0]) {
@@ -80,7 +82,7 @@ export class Copy4AIService {
                         console.error('Error using selected folder as root:', error);
                     }
                 }
-                
+
                 progress.report({ increment: 15, message: "Generating project tree..." });
                 let projectTree = '';
                 if (includeProjectTree) {
@@ -92,17 +94,17 @@ export class Copy4AIService {
                         '',
                         isExcludedByAbsolutePath
                     );
-                    
+
                     if (options.useSelectedFolderAsRoot && projectRootName) {
                         projectTree = projectRootName + '\n' + projectTree;
                     }
                 }
-                
+
                 let processedContent: FileContent[] = [];
-                
+
                 if (!options.projectTreeOnly) {
                     progress.report({ increment: 20, message: "Processing files..." });
-                    
+
                     const processOptions: ProcessFileOptions = {
                         maxFileSize: config.maxFileSize,
                         compressCode: config.compressCode,
@@ -110,20 +112,20 @@ export class Copy4AIService {
                         isExcludedByAbsolutePath,
                         shouldExcludeContent
                     };
-                    
+
                     const totalItems = itemsToProcess.length;
                     for (let i = 0; i < totalItems; i++) {
                         if (token.isCancellationRequested) {
                             throw new Error('Operation cancelled');
                         }
-                        
+
                         const item = itemsToProcess[i];
                         const progressPercent = Math.floor(20 + ((i / totalItems) * 40));
-                        progress.report({ 
-                            increment: progressPercent / totalItems, 
-                            message: `Processing ${i+1}/${totalItems}: ${path.basename(item.fsPath)}` 
+                        progress.report({
+                            increment: progressPercent / totalItems,
+                            message: `Processing ${i + 1}/${totalItems}: ${path.basename(item.fsPath)}`
                         });
-                        
+
                         const stats = await fs.stat(item.fsPath);
                         if (stats.isDirectory()) {
                             const dirResults = await FileProcessor.processDirectory(
@@ -146,9 +148,9 @@ export class Copy4AIService {
                         }
                     }
                 }
-                
+
                 progress.report({ increment: 10, message: "Formatting output..." });
-                
+
                 let formattedContent: string;
                 if (options.projectTreeOnly) {
                     formattedContent = OutputFormatter.formatProjectStructureOnly(
@@ -162,10 +164,10 @@ export class Copy4AIService {
                         processedContent
                     );
                 }
-                
+
                 progress.report({ increment: 5, message: "Copying to clipboard..." });
                 await vscode.env.clipboard.writeText(formattedContent);
-                
+
                 // Optional token counting helps users understand LLM input costs and limits
                 if (config.enableTokenCounting && !options.projectTreeOnly) {
                     progress.report({ increment: 5, message: "Counting tokens..." });
@@ -179,7 +181,7 @@ export class Copy4AIService {
                 } else {
                     vscode.window.showInformationMessage(`Copied to clipboard: ${config.outputFormat} format`);
                 }
-                
+
             } catch (error) {
                 const errorMessage = error instanceof Error ? error.message : 'Unknown error';
                 vscode.window.showErrorMessage(`Copy4AI Error: ${errorMessage}`);
@@ -200,21 +202,21 @@ export function activate(context: vscode.ExtensionContext): void {
             }
         }
     );
-    
+
     const copyProjectStructureCommand = vscode.commands.registerCommand(
         'snapsource.copyProjectStructure',
         async (uri?: vscode.Uri) => {
             try {
                 let targetUri = uri;
-                
+
                 if (!targetUri && (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0)) {
                     throw new Error('No workspace open. Please open a workspace to copy project structure.');
                 }
-                
+
                 if (!targetUri && vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
                     targetUri = vscode.workspace.workspaceFolders[0].uri;
                 }
-                
+
                 await Copy4AIService.copyToClipboard(targetUri, undefined, {
                     projectTreeOnly: true,
                     useSelectedFolderAsRoot: true
@@ -225,7 +227,7 @@ export function activate(context: vscode.ExtensionContext): void {
             }
         }
     );
-    
+
     const toggleProjectTreeCommand = vscode.commands.registerCommand(
         'snapsource.toggleProjectTree',
         async () => {
@@ -237,7 +239,7 @@ export function activate(context: vscode.ExtensionContext): void {
             }
         }
     );
-    
+
     const toggleDotFilesCommand = vscode.commands.registerCommand(
         'snapsource.toggleDotFiles',
         async () => {
@@ -249,16 +251,48 @@ export function activate(context: vscode.ExtensionContext): void {
             }
         }
     );
-    
+
+    const selectAndCopyCommand = vscode.commands.registerCommand(
+        'snapsource.selectAndCopy',
+        async (uri?: vscode.Uri) => {
+            try {
+                let targetUri = uri;
+
+                if (!targetUri && vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
+                    targetUri = vscode.workspace.workspaceFolders[0].uri;
+                }
+
+                if (!targetUri) {
+                    throw new Error('No folder selected and no workspace open.');
+                }
+
+                // If user right-clicked a file, use its parent directory
+                const stat = await vscode.workspace.fs.stat(targetUri);
+                const folderPath = stat.type === vscode.FileType.Directory
+                    ? targetUri.fsPath
+                    : require('path').dirname(targetUri.fsPath);
+
+                await FilePickerPanel.createOrShow(
+                    context.extensionUri,
+                    folderPath
+                );
+            } catch (error) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                vscode.window.showErrorMessage(`Copy4AI Error: ${errorMessage}`);
+            }
+        }
+    );
+
     context.subscriptions.push(
         copyToClipboardCommand,
         copyProjectStructureCommand,
         toggleProjectTreeCommand,
-        toggleDotFilesCommand
+        toggleDotFilesCommand,
+        selectAndCopyCommand
     );
 }
 
-export function deactivate(): void {}
+export function deactivate(): void { }
 
 // Export modern API for testing and external use
 export { OutputFormatter } from './utils/formatters';
@@ -266,4 +300,5 @@ export { FileProcessor } from './utils/fileProcessor';
 export { IgnoreUtils } from './utils/ignoreUtils';
 export { ConfigurationService } from './utils/configuration';
 export { ProjectTreeGenerator } from './utils/projectTree';
-export { TokenCounter } from './utils/tokenCounter'; 
+export { TokenCounter } from './utils/tokenCounter';
+export { TreeBuilder } from './utils/treeBuilder';

--- a/src/filePickerPanel.ts
+++ b/src/filePickerPanel.ts
@@ -1,0 +1,297 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import { ConfigurationService } from './utils/configuration';
+import { IgnoreUtils } from './utils/ignoreUtils';
+import { FileProcessor } from './utils/fileProcessor';
+import { OutputFormatter } from './utils/formatters';
+import { TokenCounter } from './utils/tokenCounter';
+import { TreeBuilder, TreeBuildOptions } from './utils/treeBuilder';
+import { FileContent, ProcessFileOptions } from './types';
+
+interface PickerToggles {
+  showDotFiles: boolean;
+  showGitIgnored: boolean;
+}
+
+export class FilePickerPanel {
+  public static currentPanel: FilePickerPanel | undefined;
+  private static readonly viewType = 'copy4aiFilePicker';
+
+  private readonly _panel: vscode.WebviewPanel;
+  private readonly _folderPath: string;
+  private readonly _workspaceRoot: string;
+  private readonly _extensionUri: vscode.Uri;
+
+  public static async createOrShow(
+    extensionUri: vscode.Uri,
+    folderPath: string
+  ): Promise<void> {
+    const column = vscode.ViewColumn.One;
+
+    if (FilePickerPanel.currentPanel) {
+      FilePickerPanel.currentPanel._panel.reveal(column);
+      await FilePickerPanel.currentPanel._sendTree({
+        showDotFiles: false,
+        showGitIgnored: false,
+      });
+      return;
+    }
+
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(
+      vscode.Uri.file(folderPath)
+    );
+    if (!workspaceFolder) {
+      vscode.window.showErrorMessage('No workspace folder found');
+      return;
+    }
+
+    const panel = vscode.window.createWebviewPanel(
+      FilePickerPanel.viewType,
+      `Select & Copy (Copy4AI) — ${path.basename(folderPath)}`,
+      column,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [vscode.Uri.joinPath(extensionUri, 'media')],
+      }
+    );
+
+    FilePickerPanel.currentPanel = new FilePickerPanel(
+      panel,
+      folderPath,
+      workspaceFolder.uri.fsPath,
+      extensionUri
+    );
+  }
+
+  private constructor(
+    panel: vscode.WebviewPanel,
+    folderPath: string,
+    workspaceRoot: string,
+    extensionUri: vscode.Uri
+  ) {
+    this._panel = panel;
+    this._folderPath = folderPath;
+    this._workspaceRoot = workspaceRoot;
+    this._extensionUri = extensionUri;
+
+    this._panel.webview.html = this._getHtml();
+
+    this._panel.webview.onDidReceiveMessage(async (msg) => {
+      switch (msg.command) {
+        case 'ready':
+          await this._sendTree({
+            showDotFiles: false,
+            showGitIgnored: false,
+          });
+          break;
+
+        case 'refreshTree': {
+          const toggles: PickerToggles = {
+            showDotFiles: msg.showDotFiles ?? false,
+            showGitIgnored: msg.showGitIgnored ?? false,
+          };
+          await this._sendTree(toggles, msg.currentSelection);
+          break;
+        }
+
+        case 'copy': {
+          const selectedPaths: string[] = msg.selectedPaths;
+          await this._copySelected(selectedPaths);
+          break;
+        }
+
+        case 'cancel':
+          this._panel.dispose();
+          break;
+      }
+    });
+
+    this._panel.onDidDispose(() => {
+      FilePickerPanel.currentPanel = undefined;
+    });
+  }
+
+  /**
+   * Builds the ignore instance with overrides from the picker toggles.
+   * 
+   * When "Show dot files" is checked, we skip adding dot file ignore rules.
+   * When "Show .gitignore'd files" is checked, we skip loading .gitignore.
+   * This lets the TreeBuilder actually see those files.
+   */
+  private async _buildIgnoreInstance(toggles: PickerToggles): Promise<any> {
+    const config = ConfigurationService.getConfiguration();
+    const excludeConfig = ConfigurationService.getExcludeConfig();
+
+    // If user toggled "Show dot files", don't add the dot file ignore rule
+    const effectiveIgnoreDotFiles = toggles.showDotFiles
+      ? false
+      : config.ignoreDotFiles;
+
+    const ig = IgnoreUtils.createIgnoreInstance(
+      excludeConfig.patterns,
+      effectiveIgnoreDotFiles
+    );
+
+    // If user toggled "Show .gitignore'd files", don't load .gitignore rules
+    const effectiveIgnoreGitIgnore = toggles.showGitIgnored
+      ? false
+      : config.ignoreGitIgnore;
+
+    if (effectiveIgnoreGitIgnore) {
+      await IgnoreUtils.addGitIgnoreRules(this._workspaceRoot, ig);
+    }
+
+    return ig;
+  }
+
+  private async _sendTree(
+    toggles: PickerToggles,
+    preserveSelection?: string[]
+  ): Promise<void> {
+    const config = ConfigurationService.getConfiguration();
+    const excludeConfig = ConfigurationService.getExcludeConfig();
+
+    const ig = await this._buildIgnoreInstance(toggles);
+
+    const isExcludedByAbsolutePath = IgnoreUtils.createAbsolutePathExclusionFn(
+      this._workspaceRoot,
+      excludeConfig.paths
+    );
+
+    const shouldExcludeContent = IgnoreUtils.createContentExclusionFn(
+      this._workspaceRoot,
+      config.excludeContentPatterns
+    );
+
+    const options: TreeBuildOptions = {
+      ig,
+      isExcludedByAbsolutePath,
+      shouldExcludeContent,
+      maxFileSize: config.maxFileSize,
+      ignoreDotFiles: toggles.showDotFiles ? false : config.ignoreDotFiles,
+      ignoreGitIgnore: toggles.showGitIgnored ? false : config.ignoreGitIgnore,
+    };
+
+    // When toggles are active, we want to see everything including ignored files
+    const includeIgnored = toggles.showDotFiles || toggles.showGitIgnored;
+
+    const tree = await TreeBuilder.buildTree(
+      this._folderPath,
+      this._workspaceRoot,
+      options,
+      includeIgnored
+    );
+
+    const defaultSelected = TreeBuilder.collectNonIgnoredFiles(tree);
+
+    this._panel.webview.postMessage({
+      command: 'loadTree',
+      tree,
+      folderName: path.basename(this._folderPath),
+      defaultSelected,
+      preserveSelection: preserveSelection || null,
+      settings: {
+        ignoreDotFiles: config.ignoreDotFiles,
+        ignoreGitIgnore: config.ignoreGitIgnore,
+        outputFormat: config.outputFormat,
+      },
+    });
+  }
+
+  private async _copySelected(selectedPaths: string[]): Promise<void> {
+    try {
+      const config = ConfigurationService.getConfiguration();
+      const excludeConfig = ConfigurationService.getExcludeConfig();
+
+      const ig = IgnoreUtils.createIgnoreInstance(
+        excludeConfig.patterns,
+        config.ignoreDotFiles
+      );
+      if (config.ignoreGitIgnore) {
+        await IgnoreUtils.addGitIgnoreRules(this._workspaceRoot, ig);
+      }
+
+      const isExcludedByAbsolutePath = IgnoreUtils.createAbsolutePathExclusionFn(
+        this._workspaceRoot,
+        excludeConfig.paths
+      );
+      const shouldExcludeContent = IgnoreUtils.createContentExclusionFn(
+        this._workspaceRoot,
+        config.excludeContentPatterns
+      );
+
+      // Use a permissive ignore instance since user explicitly selected these files
+      const permissiveIg = IgnoreUtils.createIgnoreInstance([], false);
+
+      const processOptions: ProcessFileOptions = {
+        maxFileSize: config.maxFileSize,
+        compressCode: config.compressCode,
+        removeComments: config.removeComments,
+        isExcludedByAbsolutePath: () => false,
+        shouldExcludeContent,
+      };
+
+      const entries: FileContent[] = [];
+      for (const relPath of selectedPaths) {
+        const fullPath = path.join(this._workspaceRoot, relPath);
+        const result = await FileProcessor.processFile(
+          fullPath,
+          this._workspaceRoot,
+          permissiveIg,
+          processOptions
+        );
+        if (result) {
+          entries.push(result);
+        }
+      }
+
+      let projectTree = '';
+      if (config.includeProjectTree) {
+        const { ProjectTreeGenerator } = await import('./utils/projectTree');
+        projectTree = await ProjectTreeGenerator.generateProjectTree(
+          this._folderPath,
+          ig,
+          config.maxDepth,
+          0,
+          '',
+          isExcludedByAbsolutePath
+        );
+        const folderName = path.basename(this._folderPath) + '/';
+        projectTree = folderName + '\n' + projectTree;
+      }
+
+      const formatted = OutputFormatter.formatOutput(
+        config.outputFormat,
+        projectTree,
+        entries
+      );
+
+      await vscode.env.clipboard.writeText(formatted);
+
+      if (config.enableTokenCounting) {
+        await TokenCounter.showTokenInfo(
+          formatted,
+          config.llmModel,
+          config.outputFormat,
+          config.enableTokenWarning,
+          config.maxTokens
+        );
+      } else {
+        vscode.window.showInformationMessage(
+          `Copied ${entries.length} files to clipboard (${config.outputFormat} format)`
+        );
+      }
+
+      this._panel.dispose();
+    } catch (e: any) {
+      vscode.window.showErrorMessage(`Copy4AI Error: ${e.message}`);
+    }
+  }
+
+  private _getHtml(): string {
+    const htmlPath = path.join(this._extensionUri.fsPath, 'media', 'filePicker.html');
+    return fs.readFileSync(htmlPath, 'utf-8');
+  }
+}

--- a/src/utils/treeBuilder.ts
+++ b/src/utils/treeBuilder.ts
@@ -1,0 +1,134 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { isBinaryFile } from 'isbinaryfile';
+
+export interface TreeNode {
+  name: string;
+  relativePath: string;
+  type: 'file' | 'folder';
+  ignored?: boolean;
+  children?: TreeNode[];
+}
+
+export interface TreeBuildOptions {
+  ig: any;
+  isExcludedByAbsolutePath: (filePath: string) => boolean;
+  shouldExcludeContent: (filePath: string) => boolean;
+  maxFileSize: number;
+  ignoreDotFiles: boolean;
+  ignoreGitIgnore: boolean;
+}
+
+/**
+ * Builds a tree structure for the file picker webview.
+ * 
+ * Traverses the directory recursively, marking files/folders as "ignored"
+ * based on the same rules Copy4AI uses (.gitignore, exclude patterns, etc.)
+ * so the picker UI can show them greyed out / unchecked by default.
+ */
+export class TreeBuilder {
+
+  public static async buildTree(
+    dir: string,
+    rootDir: string,
+    options: TreeBuildOptions,
+    includeIgnored: boolean = false
+  ): Promise<TreeNode[]> {
+    const nodes: TreeNode[] = [];
+
+    let items: import('fs').Dirent[];
+    try {
+      items = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return nodes;
+    }
+
+    // Sort: folders first, then files, both alphabetical
+    items.sort((a, b) => {
+      const aIsDir = a.isDirectory();
+      const bIsDir = b.isDirectory();
+      if (aIsDir && !bIsDir) { return -1; }
+      if (!aIsDir && bIsDir) { return 1; }
+      return a.name.localeCompare(b.name);
+    });
+
+    for (const item of items) {
+      const fullPath = path.join(dir, item.name);
+      const relPath = path.relative(rootDir, fullPath);
+      const relPosix = relPath.split(path.sep).join('/');
+
+      // Determine if this entry is ignored by Copy4AI's rules
+      const isIgnoredByPattern = this.safeIgnoreCheck(options.ig, relPosix);
+      const isExcludedByPath = options.isExcludedByAbsolutePath(fullPath);
+      const isIgnored = isIgnoredByPattern || isExcludedByPath;
+
+      // Skip ignored entries entirely if user doesn't want to see them
+      if (isIgnored && !includeIgnored) {
+        continue;
+      }
+
+      if (item.isDirectory()) {
+        const children = await this.buildTree(fullPath, rootDir, options, includeIgnored);
+        // Only include folders that have at least one visible child
+        if (children.length > 0 || includeIgnored) {
+          nodes.push({
+            name: item.name,
+            relativePath: relPosix,
+            type: 'folder',
+            ignored: isIgnored,
+            children,
+          });
+        }
+      } else if (item.isFile()) {
+        // Skip binary files — same logic as FileProcessor
+        try {
+          const binary = await isBinaryFile(fullPath);
+          if (binary) { continue; }
+        } catch {
+          // If we can't check, include it
+        }
+
+        // Skip files over size limit
+        try {
+          const stat = await fs.stat(fullPath);
+          if (stat.size > options.maxFileSize) { continue; }
+        } catch {
+          continue;
+        }
+
+        nodes.push({
+          name: item.name,
+          relativePath: relPosix,
+          type: 'file',
+          ignored: isIgnored,
+        });
+      }
+    }
+
+    return nodes;
+  }
+
+  /**
+   * Collects all non-ignored file paths from a tree.
+   * Used to determine the default selection set.
+   */
+  public static collectNonIgnoredFiles(nodes: TreeNode[]): string[] {
+    const files: string[] = [];
+    for (const node of nodes) {
+      if (node.type === 'file' && !node.ignored) {
+        files.push(node.relativePath);
+      } else if (node.children) {
+        files.push(...this.collectNonIgnoredFiles(node.children));
+      }
+    }
+    return files;
+  }
+
+  private static safeIgnoreCheck(ig: any, relPath: string): boolean {
+    try {
+      return ig.ignores(relPath);
+    } catch {
+      return false;
+    }
+  }
+}

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -1,10 +1,10 @@
 const assert = require('assert');
 const vscode = require('vscode');
-const { 
-    OutputFormatter, 
-    FileProcessor, 
-    IgnoreUtils, 
-    ConfigurationService 
+const {
+    OutputFormatter,
+    FileProcessor,
+    IgnoreUtils,
+    ConfigurationService
 } = require('../out/extension');
 const path = require('path');
 
@@ -29,18 +29,18 @@ suite('Copy4AI Extension Test Suite', () => {
     });
 
     suite('Extension Basics', () => {
-        test('Should register command', async function() {
+        test('Should register command', async function () {
             this.timeout(10000); // Increase timeout for this test
-            
+
             // Ensure extension is activated
             const ext = vscode.extensions.getExtension('LeonKohli.snapsource');
             if (ext && !ext.isActive) {
                 await ext.activate();
             }
-            
+
             // Wait a bit for commands to register
             await new Promise(resolve => setTimeout(resolve, 1000));
-            
+
             const commands = await vscode.commands.getCommands();
             assert.ok(commands.includes('snapsource.copyToClipboard'));
         });
@@ -119,10 +119,10 @@ suite('Copy4AI Extension Test Suite', () => {
             }];
 
             const xmlResult = OutputFormatter.formatOutput('xml', '', content);
-            
+
             // Check path attribute is properly escaped
             assert.ok(xmlResult.includes('path="test &amp; demo.xml"'), 'Should escape special characters in path attribute');
-            
+
             // Check content is wrapped in CDATA
             assert.ok(xmlResult.includes('<![CDATA[<test>Hello & World</test>]]>'), 'Should wrap content in CDATA');
         });
@@ -148,7 +148,7 @@ suite('Copy4AI Extension Test Suite', () => {
             ];
 
             const markdownResult = OutputFormatter.formatOutput('markdown', '', content);
-            
+
             // Check language-specific code blocks
             assert.ok(markdownResult.includes('```python\nprint("Hello")'), 'Should use python language for Python files');
             assert.ok(markdownResult.includes('```css\nbody { color: red; }'), 'Should use css language for CSS files');
@@ -165,7 +165,7 @@ suite('Copy4AI Extension Test Suite', () => {
                 assert.ok(!result.includes('undefined'), `${format} format should not contain undefined`);
                 assert.strictEqual(result, '', `${format} format should return empty string for empty content and tree`);
             }
-            
+
             // Test XML format (returns basic XML structure even when empty)
             const xmlResult = OutputFormatter.formatOutput('xml', '', []);
             assert.ok(typeof xmlResult === 'string', 'XML format should return a string');
@@ -183,11 +183,11 @@ suite('Copy4AI Extension Test Suite', () => {
             }];
 
             const result = OutputFormatter.formatOutput('markdown', '', content);
-            
+
             assert.ok(result.includes('````markdown'), 'Should use 4 backticks for outer fence when content has 3');
             assert.ok(result.includes('```sh'), 'Inner code block should remain unchanged');
             assert.ok(result.includes('npm i -S my-project'), 'Content should be preserved');
-            
+
             const outerFenceCount = (result.match(/````/g) || []).length;
             assert.strictEqual(outerFenceCount, 2, 'Should have exactly 2 quadruple-backtick fences (open and close)');
         });
@@ -200,7 +200,7 @@ suite('Copy4AI Extension Test Suite', () => {
             }];
 
             const result = OutputFormatter.formatOutput('markdown', '', content);
-            
+
             assert.ok(result.includes('`````markdown'), 'Should use 5 backticks when content has 4');
         });
 
@@ -266,7 +266,7 @@ suite('Copy4AI Extension Test Suite', () => {
                     console.log("test");  // Inline comment
                 }
             `;
-            
+
             const expectedAfterCommentRemoval = `
                 
                 function test() {
@@ -274,15 +274,15 @@ suite('Copy4AI Extension Test Suite', () => {
                     console.log("test");  
                 }
             `;
-            
+
             const expectedFinal = 'function test() {\nconsole.log("test");\n}';
-            
+
             const withoutComments = FileProcessor.removeCodeComments(input);
             assert.strictEqual(withoutComments, expectedAfterCommentRemoval, 'Should remove all comments');
-            
+
             const compressed = FileProcessor.compressCodeContent(withoutComments);
             assert.strictEqual(compressed, expectedFinal, 'Should compress code after comment removal');
-            
+
             // Test processContent function directly
             const processed = FileProcessor.processContent(input, true, true);
             assert.strictEqual(processed, expectedFinal, 'Should process content with both options');
@@ -290,34 +290,34 @@ suite('Copy4AI Extension Test Suite', () => {
     });
 
     suite('Command Functionality', () => {
-        test('Should respect configuration settings', async function() {
+        test('Should respect configuration settings', async function () {
             this.timeout(30000);
-            
+
             // Get the configuration
             const config = vscode.workspace.getConfiguration('copy4ai');
-            
+
             try {
                 // Reset settings first to ensure clean state
                 await config.update('outputFormat', undefined, vscode.ConfigurationTarget.Global);
                 await config.update('maxDepth', undefined, vscode.ConfigurationTarget.Global);
-                
+
                 // Wait for settings to be reset
                 await new Promise(resolve => setTimeout(resolve, 1000));
-                
+
                 // Update settings
                 await config.update('outputFormat', 'markdown', vscode.ConfigurationTarget.Global);
                 await config.update('maxDepth', 5, vscode.ConfigurationTarget.Global);
-                
+
                 // Wait for settings to be applied
                 await new Promise(resolve => setTimeout(resolve, 1000));
-                
+
                 // Get a fresh configuration instance
                 const updatedConfig = vscode.workspace.getConfiguration('copy4ai');
-                
+
                 // Verify settings
                 const format = updatedConfig.get('outputFormat');
                 const depth = updatedConfig.get('maxDepth');
-                
+
                 assert.strictEqual(format, 'markdown', 'Should update output format setting');
                 assert.strictEqual(depth, 5, 'Should update max depth setting');
             } finally {
@@ -331,25 +331,25 @@ suite('Copy4AI Extension Test Suite', () => {
             // Ensure testWorkspace directory exists
             const testWorkspacePath = path.join(__dirname, 'testWorkspace');
             await vscode.workspace.fs.createDirectory(vscode.Uri.file(testWorkspacePath));
-            
+
             const testFilePath = path.join(testWorkspacePath, 'test.bin');
             const buffer = Buffer.from([0x89, 0x50, 0x4E, 0x47]); // PNG magic number
-            
+
             // Create a binary file
             await vscode.workspace.fs.writeFile(vscode.Uri.file(testFilePath), buffer);
 
             try {
                 // Open the workspace where the file is located
                 await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(testWorkspacePath));
-                
+
                 // Wait for workspace to open
                 await new Promise(resolve => setTimeout(resolve, 500));
-                
+
                 const uri = vscode.Uri.file(testFilePath);
                 await vscode.commands.executeCommand('snapsource.copyToClipboard', uri);
-                
+
                 const clipboardContent = await vscode.env.clipboard.readText();
-                assert.ok(clipboardContent.includes('[Binary file content not included]'), 
+                assert.ok(clipboardContent.includes('[Binary file content not included]'),
                     'Should indicate binary file content is not included');
             } finally {
                 // Cleanup
@@ -365,27 +365,27 @@ suite('Copy4AI Extension Test Suite', () => {
             // Ensure testWorkspace directory exists
             const testWorkspacePath = path.join(__dirname, 'testWorkspace');
             await vscode.workspace.fs.createDirectory(vscode.Uri.file(testWorkspacePath));
-            
+
             const testFilePath = path.join(testWorkspacePath, 'large.txt');
             const largeContent = 'x'.repeat(2 * 1024 * 1024); // 2MB file
-            
+
             // Create a large file
             await vscode.workspace.fs.writeFile(vscode.Uri.file(testFilePath), Buffer.from(largeContent));
 
             try {
                 // Ensure we're in the right workspace
-                if (!vscode.workspace.workspaceFolders || 
+                if (!vscode.workspace.workspaceFolders ||
                     !vscode.workspace.workspaceFolders[0].uri.fsPath.includes('testWorkspace')) {
                     await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(testWorkspacePath));
                     // Wait for workspace to open
                     await new Promise(resolve => setTimeout(resolve, 500));
                 }
-                
+
                 const uri = vscode.Uri.file(testFilePath);
                 await vscode.commands.executeCommand('snapsource.copyToClipboard', uri);
-                
+
                 const clipboardContent = await vscode.env.clipboard.readText();
-                assert.ok(clipboardContent.includes('[File too large:') && clipboardContent.includes('2.0 MB'), 
+                assert.ok(clipboardContent.includes('[File too large:') && clipboardContent.includes('2.0 MB'),
                     'Should indicate file size exceeds limit');
             } finally {
                 // Cleanup
@@ -397,13 +397,13 @@ suite('Copy4AI Extension Test Suite', () => {
             }
         });
 
-        test('Should handle multiple file selection', async function() {
+        test('Should handle multiple file selection', async function () {
             this.timeout(10000); // Increase timeout for this test
-            
+
             // Ensure testWorkspace directory exists
             const testWorkspacePath = path.join(__dirname, 'testWorkspace');
             await vscode.workspace.fs.createDirectory(vscode.Uri.file(testWorkspacePath));
-            
+
             const testFiles = [
                 { name: 'test1.txt', content: 'Test content 1' },
                 { name: 'test2.txt', content: 'Test content 2' }
@@ -425,19 +425,19 @@ suite('Copy4AI Extension Test Suite', () => {
                 await new Promise(resolve => setTimeout(resolve, 500));
 
                 // Ensure we're in the right workspace
-                if (!vscode.workspace.workspaceFolders || 
+                if (!vscode.workspace.workspaceFolders ||
                     !vscode.workspace.workspaceFolders[0].uri.fsPath.includes('testWorkspace')) {
                     await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(testWorkspacePath));
                     // Wait for workspace to open
                     await new Promise(resolve => setTimeout(resolve, 1000));
                 }
-                
+
                 // Test multiple file selection
                 await vscode.commands.executeCommand('snapsource.copyToClipboard', uris[0], uris);
-                
+
                 // Ensure clipboard is updated before reading
                 await new Promise(resolve => setTimeout(resolve, 500));
-                
+
                 const clipboardContent = await vscode.env.clipboard.readText();
                 assert.ok(clipboardContent.includes('Test content 1'), 'Should include first file content');
                 assert.ok(clipboardContent.includes('Test content 2'), 'Should include second file content');
@@ -453,83 +453,83 @@ suite('Copy4AI Extension Test Suite', () => {
             }
         });
     });
-    
+
 
     suite('Exclusion Patterns', () => {
         test('Should exclude files using glob patterns', () => {
             // Create an ignore instance with standard patterns
             const ig = IgnoreUtils.createIgnoreInstance(['config', '*.log']);
-            
+
             // Test paths - use platform-agnostic path handling
             const relativePath1 = path.join('src', 'config');
             const relativePath2 = path.join('vendor', 'package', 'config');
-            
+
             // Both should be excluded with the generic pattern
             assert.strictEqual(ig.ignores(relativePath1), true);
             assert.strictEqual(ig.ignores(relativePath2), true);
         });
-        
+
         test('Should exclude specific paths with absolute path exclusion', () => {
             // Create a mock workspace path that's platform-independent
             const workspacePath = path.resolve('/mock/workspace');
-            
+
             // Define absolute paths to exclude with platform-independent path
             const absolutePathsToExclude = [path.join('src', 'config')];
-            
+
             // Create the exclusion function using the helper
             const isExcludedByAbsolutePath = IgnoreUtils.createAbsolutePathExclusionFn(
-                workspacePath, 
+                workspacePath,
                 absolutePathsToExclude
             );
-            
+
             // Test paths with platform-independent join
             const filePath1 = path.join(workspacePath, 'src', 'config');
             const filePath2 = path.join(workspacePath, 'vendor', 'package', 'config');
             const filePath3 = path.join(workspacePath, 'src', 'config', 'settings.json');
-            
+
             // Verify exclusions
             assert.strictEqual(isExcludedByAbsolutePath(filePath1), true, 'src/config should be excluded');
             assert.strictEqual(isExcludedByAbsolutePath(filePath2), false, 'vendor/package/config should not be excluded');
             assert.strictEqual(isExcludedByAbsolutePath(filePath3), true, 'src/config/settings.json should be excluded');
         });
-        
+
         test('Should handle combined exclusion patterns correctly', () => {
             // Create a mock workspace path with platform-independent path
             const workspacePath = path.resolve('/mock/workspace');
-            
+
             // Create an ignore instance with standard patterns
             const ig = IgnoreUtils.createIgnoreInstance(['*.log', '*.tmp']);
-            
+
             // Create the absolute path exclusion function with platform-independent path
             const isExcludedByAbsolutePath = IgnoreUtils.createAbsolutePathExclusionFn(
-                workspacePath, 
+                workspacePath,
                 [path.join('src', 'config')]
             );
-            
+
             // Test paths with platform-independent joins
             const paths = [
-                { 
-                    path: path.join(workspacePath, 'src', 'config', 'app.js'), 
-                    expected: true, 
-                    message: 'src/config/app.js should be excluded by absolute path' 
+                {
+                    path: path.join(workspacePath, 'src', 'config', 'app.js'),
+                    expected: true,
+                    message: 'src/config/app.js should be excluded by absolute path'
                 },
-                { 
-                    path: path.join(workspacePath, 'src', 'utils', 'app.log'), 
-                    expected: true, 
-                    message: 'src/utils/app.log should be excluded by pattern' 
+                {
+                    path: path.join(workspacePath, 'src', 'utils', 'app.log'),
+                    expected: true,
+                    message: 'src/utils/app.log should be excluded by pattern'
                 },
-                { 
-                    path: path.join(workspacePath, 'vendor', 'package', 'config', 'app.js'), 
-                    expected: false, 
-                    message: 'vendor/package/config/app.js should not be excluded' 
+                {
+                    path: path.join(workspacePath, 'vendor', 'package', 'config', 'app.js'),
+                    expected: false,
+                    message: 'vendor/package/config/app.js should not be excluded'
                 },
-                { 
-                    path: path.join(workspacePath, 'src', 'app.js'), 
-                    expected: false, 
-                    message: 'src/app.js should not be excluded' 
+                {
+                    path: path.join(workspacePath, 'src', 'app.js'),
+                    expected: false,
+                    message: 'src/app.js should not be excluded'
                 }
             ];
-            
+
             // Test each path
             paths.forEach(testPath => {
                 const relativePath = path.relative(workspacePath, testPath.path);
@@ -538,108 +538,108 @@ suite('Copy4AI Extension Test Suite', () => {
             });
         });
 
-        test('Should respect exclude configuration in workspace settings', async function() {
+        test('Should respect exclude configuration in workspace settings', async function () {
             this.timeout(10000); // Increase timeout for this test
-            
+
             // Get the test workspace path
             const testWorkspacePath = path.join(__dirname, 'testWorkspace');
-            
+
             try {
                 // Open the test workspace
                 await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(testWorkspacePath));
-                
+
                 // Wait for workspace to open and settings to be loaded
                 await new Promise(resolve => setTimeout(resolve, 2000));
-                
+
                 // Get the configuration
                 const config = vscode.workspace.getConfiguration('copy4ai');
                 const excludeConfig = config.get('exclude');
-                
+
                 // Verify the exclude configuration is loaded correctly
                 assert.ok(excludeConfig, 'Exclude configuration should be present');
                 assert.deepStrictEqual(excludeConfig.paths, ['src/config'], 'Should have correct paths in exclude config');
                 assert.deepStrictEqual(excludeConfig.patterns, ['*.log'], 'Should have correct patterns in exclude config');
-                
+
                 // Test copying the project structure
                 await vscode.commands.executeCommand('snapsource.copyProjectStructure');
-                
+
                 // Wait longer for the command to complete and clipboard to update
                 await new Promise(resolve => setTimeout(resolve, 3000));
-                
+
                 // Get clipboard content
                 const clipboardContent = await vscode.env.clipboard.readText();
-                
+
                 // For debugging purposes only - can be removed in production
                 // console.log('Clipboard content:', clipboardContent);
-                
+
                 // Verify src/config is excluded
                 const srcConfigIncluded = clipboardContent.includes('src/config/config.js');
                 assert.strictEqual(srcConfigIncluded, false, 'src/config/config.js should be excluded');
-                
+
                 // Check if src directory is marked as having ignored files
-                const srcIgnored = clipboardContent.includes('src') && 
-                                  (clipboardContent.includes('(all files ignored)') || 
-                                   clipboardContent.includes('(excluded') || 
-                                   !clipboardContent.includes('src/config'));
+                const srcIgnored = clipboardContent.includes('src') &&
+                    (clipboardContent.includes('(all files ignored)') ||
+                        clipboardContent.includes('(excluded') ||
+                        !clipboardContent.includes('src/config'));
                 assert.strictEqual(srcIgnored, true, 'src directory should indicate files are ignored or excluded');
-                
+
                 // Verify vendor/package/config is included
-                const vendorPathIncluded = clipboardContent.includes('vendor') && 
-                                          clipboardContent.includes('package') && 
-                                          clipboardContent.includes('config');
+                const vendorPathIncluded = clipboardContent.includes('vendor') &&
+                    clipboardContent.includes('package') &&
+                    clipboardContent.includes('config');
                 assert.strictEqual(vendorPathIncluded, true, 'vendor/package/config path structure should be included');
             } finally {
                 // Return to the original workspace if needed
                 // This step might be optional depending on your test setup
             }
         });
-        
-        test('Should use selected folder as root for project structure', async function() {
+
+        test('Should use selected folder as root for project structure', async function () {
             this.timeout(10000); // Increase timeout for this test
-            
+
             // Get the test workspace path
             const testWorkspacePath = path.join(__dirname, 'testWorkspace');
-            
+
             try {
                 // Create a test subfolder structure
                 const subfolderPath = path.join(testWorkspacePath, 'subfolder');
                 const subfileAPath = path.join(subfolderPath, 'fileA.txt');
                 const subfileBPath = path.join(subfolderPath, 'fileB.txt');
-                
+
                 await vscode.workspace.fs.createDirectory(vscode.Uri.file(subfolderPath));
                 await vscode.workspace.fs.writeFile(
-                    vscode.Uri.file(subfileAPath), 
+                    vscode.Uri.file(subfileAPath),
                     Buffer.from('Test content A')
                 );
                 await vscode.workspace.fs.writeFile(
-                    vscode.Uri.file(subfileBPath), 
+                    vscode.Uri.file(subfileBPath),
                     Buffer.from('Test content B')
                 );
-                
+
                 // Open the test workspace
                 await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(testWorkspacePath));
-                
+
                 // Wait for workspace to open
                 await new Promise(resolve => setTimeout(resolve, 2000));
-                
+
                 // Call the copyProjectStructure command with the subfolder URI
                 await vscode.commands.executeCommand(
-                    'snapsource.copyProjectStructure', 
+                    'snapsource.copyProjectStructure',
                     vscode.Uri.file(subfolderPath)
                 );
-                
+
                 // Wait for the command to complete
                 await new Promise(resolve => setTimeout(resolve, 3000));
-                
+
                 // Read the clipboard content
                 const clipboardContent = await vscode.env.clipboard.readText();
-                
+
                 // Verify the clipboard content only includes the subfolder structure
                 assert.ok(clipboardContent.includes('subfolder/'), 'Should include subfolder name at the top');
                 assert.ok(clipboardContent.includes('fileA.txt'), 'Should include subfolder files');
                 assert.ok(clipboardContent.includes('fileB.txt'), 'Should include subfolder files');
                 assert.ok(!clipboardContent.includes('src/config'), 'Should not include workspace root files');
-                
+
             } finally {
                 // Cleanup
                 try {
@@ -651,52 +651,52 @@ suite('Copy4AI Extension Test Suite', () => {
             }
         });
 
-        test('Should handle encoding issues gracefully and continue processing other files', async function() {
+        test('Should handle encoding issues gracefully and continue processing other files', async function () {
             this.timeout(15000); // Increase timeout for this test
-            
+
             // Get the test workspace path
             const testWorkspacePath = path.join(__dirname, 'testWorkspace');
-            
+
             try {
                 // Open the test workspace (it already has UTF-16 LE requirements.txt and other files)
                 await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(testWorkspacePath));
-                
+
                 // Wait for workspace to open
                 await new Promise(resolve => setTimeout(resolve, 2000));
-                
+
                 // Copy the entire test workspace content
                 await vscode.commands.executeCommand(
-                    'snapsource.copyToClipboard', 
+                    'snapsource.copyToClipboard',
                     vscode.Uri.file(testWorkspacePath)
                 );
-                
+
                 // Wait for the command to complete
                 await new Promise(resolve => setTimeout(resolve, 3000));
-                
+
                 // Read the clipboard content
                 const clipboardContent = await vscode.env.clipboard.readText();
-                
+
 
                 // Verify that UTF-16 file is handled gracefully
                 assert.ok(clipboardContent.includes('requirements.txt'), 'Should include requirements.txt file path');
-                assert.ok(clipboardContent.includes('Binary file content not included') || 
-                         clipboardContent.includes('unsupported encoding') ||
-                         clipboardContent.includes('UTF-16') ||
-                         clipboardContent.includes('convert to UTF-8') ||
-                         clipboardContent.includes('appears to be UTF-16'), 
-                         'Should indicate that requirements.txt content is not included due to encoding/binary detection');
-                
+                assert.ok(clipboardContent.includes('Binary file content not included') ||
+                    clipboardContent.includes('unsupported encoding') ||
+                    clipboardContent.includes('UTF-16') ||
+                    clipboardContent.includes('convert to UTF-8') ||
+                    clipboardContent.includes('appears to be UTF-16'),
+                    'Should indicate that requirements.txt content is not included due to encoding/binary detection');
+
                 // Verify that other Python files are still processed despite the encoding error
                 assert.ok(clipboardContent.includes('starthanders.py'), 'Should include starthanders.py file');
                 assert.ok(clipboardContent.includes('urlhandlers.py'), 'Should include urlhandlers.py file');
                 assert.ok(clipboardContent.includes('def start_handler'), 'Should include content from starthanders.py');
                 assert.ok(clipboardContent.includes('def handle_url'), 'Should include content from urlhandlers.py');
-                
+
                 // Verify all files are listed in the project structure, even if content can't be read
-                assert.ok(clipboardContent.includes('Project Structure') || 
-                         clipboardContent.includes('File Contents'), 
-                         'Should include structure/content headers');
-                
+                assert.ok(clipboardContent.includes('Project Structure') ||
+                    clipboardContent.includes('File Contents'),
+                    'Should include structure/content headers');
+
             } finally {
                 // Note: We don't clean up the test files as they're part of the test workspace
             }
@@ -704,12 +704,12 @@ suite('Copy4AI Extension Test Suite', () => {
 
         test('createContentExclusionFn should match files by glob pattern', () => {
             const workspacePath = path.resolve('/mock/workspace');
-            
+
             const shouldExcludeContent = IgnoreUtils.createContentExclusionFn(
                 workspacePath,
                 ['**/*.svg', '**/*.png', 'assets/**']
             );
-            
+
             const testCases = [
                 { file: path.join(workspacePath, 'icon.svg'), expected: true },
                 { file: path.join(workspacePath, 'images', 'logo.png'), expected: true },
@@ -717,10 +717,10 @@ suite('Copy4AI Extension Test Suite', () => {
                 { file: path.join(workspacePath, 'src', 'app.js'), expected: false },
                 { file: path.join(workspacePath, 'README.md'), expected: false },
             ];
-            
+
             testCases.forEach(tc => {
                 const result = shouldExcludeContent(tc.file);
-                assert.strictEqual(result, tc.expected, 
+                assert.strictEqual(result, tc.expected,
                     `${tc.file} should ${tc.expected ? 'be excluded' : 'not be excluded'}`);
             });
         });
@@ -728,9 +728,253 @@ suite('Copy4AI Extension Test Suite', () => {
         test('createContentExclusionFn should return false when patterns empty', () => {
             const workspacePath = path.resolve('/mock/workspace');
             const shouldExcludeContent = IgnoreUtils.createContentExclusionFn(workspacePath, []);
-            
+
             assert.strictEqual(shouldExcludeContent(path.join(workspacePath, 'any.svg')), false);
             assert.strictEqual(shouldExcludeContent(path.join(workspacePath, 'file.png')), false);
+        });
+    });
+
+    suite('TreeBuilder', () => {
+        const { TreeBuilder } = require('../out/utils/treeBuilder');
+        const testWorkspacePath = path.join(__dirname, 'testWorkspace');
+
+        test('Should build tree structure from directory', async function () {
+            this.timeout(10000);
+
+            const ig = IgnoreUtils.createIgnoreInstance(['*.log'], true);
+            await IgnoreUtils.addGitIgnoreRules(testWorkspacePath, ig);
+
+            const options = {
+                ig,
+                isExcludedByAbsolutePath: () => false,
+                shouldExcludeContent: () => false,
+                maxFileSize: 1024 * 1024,
+                ignoreDotFiles: true,
+                ignoreGitIgnore: true,
+            };
+
+            const tree = await TreeBuilder.buildTree(
+                testWorkspacePath,
+                testWorkspacePath,
+                options,
+                false
+            );
+
+            assert.ok(Array.isArray(tree), 'Tree should be an array');
+            assert.ok(tree.length > 0, 'Tree should have entries');
+
+            // Check that folders come with type and children
+            const srcFolder = tree.find(n => n.name === 'src');
+            if (srcFolder) {
+                assert.strictEqual(srcFolder.type, 'folder', 'src should be a folder');
+                assert.ok(Array.isArray(srcFolder.children), 'Folder should have children array');
+            }
+
+            // Check that files come with type 'file'
+            const appFile = tree.find(n => n.name === 'app.js');
+            assert.ok(appFile, 'Should include app.js');
+            assert.strictEqual(appFile.type, 'file', 'app.js should be type file');
+            assert.strictEqual(appFile.relativePath, 'app.js', 'relativePath should be correct');
+        });
+
+        test('Should mark ignored files when includeIgnored is true', async function () {
+            this.timeout(10000);
+
+            // Create an ignore instance that ignores Python files
+            const ig = IgnoreUtils.createIgnoreInstance(['*.py'], false);
+
+            const options = {
+                ig,
+                isExcludedByAbsolutePath: () => false,
+                shouldExcludeContent: () => false,
+                maxFileSize: 1024 * 1024,
+                ignoreDotFiles: false,
+                ignoreGitIgnore: false,
+            };
+
+            const tree = await TreeBuilder.buildTree(
+                testWorkspacePath,
+                testWorkspacePath,
+                options,
+                true // includeIgnored
+            );
+
+            // Find a .py file — it should exist but be marked as ignored
+            const pyFile = tree.find(n => n.name === 'starthanders.py');
+            assert.ok(pyFile, 'Should include starthanders.py when includeIgnored is true');
+            assert.strictEqual(pyFile.ignored, true, 'Python file should be marked as ignored');
+
+            // Non-ignored files should have ignored === false
+            const appFile = tree.find(n => n.name === 'app.js');
+            assert.ok(appFile, 'Should include app.js');
+            assert.strictEqual(appFile.ignored, false, 'app.js should not be marked as ignored');
+        });
+
+        test('Should exclude ignored files when includeIgnored is false', async function () {
+            this.timeout(10000);
+
+            const ig = IgnoreUtils.createIgnoreInstance(['*.py'], false);
+
+            const options = {
+                ig,
+                isExcludedByAbsolutePath: () => false,
+                shouldExcludeContent: () => false,
+                maxFileSize: 1024 * 1024,
+                ignoreDotFiles: false,
+                ignoreGitIgnore: false,
+            };
+
+            const tree = await TreeBuilder.buildTree(
+                testWorkspacePath,
+                testWorkspacePath,
+                options,
+                false // includeIgnored
+            );
+
+            const pyFile = tree.find(n => n.name === 'starthanders.py');
+            assert.strictEqual(pyFile, undefined, 'Should not include .py files when includeIgnored is false');
+
+            const appFile = tree.find(n => n.name === 'app.js');
+            assert.ok(appFile, 'Should still include non-ignored files');
+        });
+
+        test('Should respect absolute path exclusions', async function () {
+            this.timeout(10000);
+
+            const ig = IgnoreUtils.createIgnoreInstance([], false);
+
+            const isExcludedByAbsolutePath = IgnoreUtils.createAbsolutePathExclusionFn(
+                testWorkspacePath,
+                [path.join('src', 'config')]
+            );
+
+            const options = {
+                ig,
+                isExcludedByAbsolutePath,
+                shouldExcludeContent: () => false,
+                maxFileSize: 1024 * 1024,
+                ignoreDotFiles: false,
+                ignoreGitIgnore: false,
+            };
+
+            const tree = await TreeBuilder.buildTree(
+                testWorkspacePath,
+                testWorkspacePath,
+                options,
+                false
+            );
+
+            // src folder should exist
+            const srcFolder = tree.find(n => n.name === 'src');
+
+            // If src/config was the only child, src may still appear but config should not
+            if (srcFolder && srcFolder.children) {
+                const configFolder = srcFolder.children.find(n => n.name === 'config');
+                assert.strictEqual(configFolder, undefined, 'src/config should be excluded by absolute path');
+            }
+
+            // vendor/package/config should still be there
+            const vendorFolder = tree.find(n => n.name === 'vendor');
+            assert.ok(vendorFolder, 'vendor folder should still exist');
+        });
+
+        test('collectNonIgnoredFiles should return only non-ignored file paths', () => {
+            const mockTree = [
+                {
+                    name: 'src',
+                    relativePath: 'src',
+                    type: 'folder',
+                    ignored: false,
+                    children: [
+                        { name: 'app.js', relativePath: 'src/app.js', type: 'file', ignored: false },
+                        { name: 'secret.env', relativePath: 'src/secret.env', type: 'file', ignored: true },
+                    ]
+                },
+                { name: 'README.md', relativePath: 'README.md', type: 'file', ignored: false },
+                { name: '.gitignore', relativePath: '.gitignore', type: 'file', ignored: true },
+            ];
+
+            const result = TreeBuilder.collectNonIgnoredFiles(mockTree);
+
+            assert.ok(Array.isArray(result), 'Should return an array');
+            assert.strictEqual(result.length, 2, 'Should return 2 non-ignored files');
+            assert.ok(result.includes('src/app.js'), 'Should include src/app.js');
+            assert.ok(result.includes('README.md'), 'Should include README.md');
+            assert.ok(!result.includes('src/secret.env'), 'Should not include ignored file');
+            assert.ok(!result.includes('.gitignore'), 'Should not include ignored file');
+        });
+
+        test('collectNonIgnoredFiles should handle empty tree', () => {
+            const result = TreeBuilder.collectNonIgnoredFiles([]);
+            assert.ok(Array.isArray(result), 'Should return an array');
+            assert.strictEqual(result.length, 0, 'Should return empty array for empty tree');
+        });
+
+        test('collectNonIgnoredFiles should handle deeply nested structures', () => {
+            const mockTree = [
+                {
+                    name: 'a',
+                    relativePath: 'a',
+                    type: 'folder',
+                    ignored: false,
+                    children: [
+                        {
+                            name: 'b',
+                            relativePath: 'a/b',
+                            type: 'folder',
+                            ignored: false,
+                            children: [
+                                {
+                                    name: 'c',
+                                    relativePath: 'a/b/c',
+                                    type: 'folder',
+                                    ignored: false,
+                                    children: [
+                                        { name: 'deep.js', relativePath: 'a/b/c/deep.js', type: 'file', ignored: false },
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ];
+
+            const result = TreeBuilder.collectNonIgnoredFiles(mockTree);
+            assert.strictEqual(result.length, 1, 'Should find deeply nested file');
+            assert.ok(result.includes('a/b/c/deep.js'), 'Should include deeply nested file path');
+        });
+
+        test('Should sort entries: folders first, then files, both alphabetical', async function () {
+            this.timeout(10000);
+
+            const ig = IgnoreUtils.createIgnoreInstance([], false);
+
+            const options = {
+                ig,
+                isExcludedByAbsolutePath: () => false,
+                shouldExcludeContent: () => false,
+                maxFileSize: 1024 * 1024,
+                ignoreDotFiles: false,
+                ignoreGitIgnore: false,
+            };
+
+            const tree = await TreeBuilder.buildTree(
+                testWorkspacePath,
+                testWorkspacePath,
+                options,
+                false
+            );
+
+            // Check that folders come before files
+            let seenFile = false;
+            for (const node of tree) {
+                if (node.type === 'file') {
+                    seenFile = true;
+                }
+                if (node.type === 'folder' && seenFile) {
+                    assert.fail('Folders should come before files in tree');
+                }
+            }
         });
     });
 });


### PR DESCRIPTION
Closes #19 

## Summary

Adds a new **Select & Copy (Copy4AI)** command that opens an interactive file picker, allowing users to visually choose which files to include before copying. This addresses the workflow gap where users need different file subsets for different tasks without changing config-based exclusion patterns.

## What's added

**New files:**
- `src/filePickerPanel.ts` — Webview panel that manages the picker lifecycle and communicates between the UI and Copy4AI's existing services
- `src/utils/treeBuilder.ts` — Builds a tree structure for the picker, marking files as ignored/not-ignored using the same rules as `IgnoreUtils`
- `media/filePicker.html` — The picker UI (separated from TypeScript for maintainability and proper syntax highlighting)

**Modified files:**
- `src/extension.ts` — Registers the new `snapsource.selectAndCopy` command + exports `TreeBuilder` for testing
- `package.json` — Adds command definition, context menu entry, and command palette config

**Tests:**
- Added `TreeBuilder` test suite covering: tree building from real directories, ignored file marking/exclusion, absolute path exclusions, `collectNonIgnoredFiles` with mock data (empty, nested, mixed), and sort order validation

## How it works

1. User right-clicks a folder → **Select & Copy (Copy4AI)**
2. A webview panel opens showing the folder's file tree with tri-state checkboxes
3. All non-ignored files are selected by default — user deselects what they don't need
4. Toggle checkboxes let users reveal `.gitignore`'d files and dot files on demand
5. On "Copy for AI", selected file paths are fed through `FileProcessor.processFile()` → `OutputFormatter.formatOutput()`, so all existing settings (output format, token counting, encoding handling, compression, content exclusion) are respected

## Design decisions

- **Reuses existing services** — No duplication of file processing, formatting, or ignore logic. The picker is purely a selection UI on top of Copy4AI's existing pipeline.
- **HTML in separate file** — `media/filePicker.html` is kept separate from `filePickerPanel.ts` for clean separation of concerns, proper IDE support, and easier future editing.
- **Permissive copy** — When the user explicitly selects files (including ignored ones), the copy step uses a permissive ignore instance so their selection is respected.
- **Toggle overrides** — "Show dot files" and "Show .gitignore'd files" rebuild the ignore instance with relaxed rules rather than just toggling visibility, so previously hidden files actually appear in the tree.

## Screenshot

![Animation](https://github.com/user-attachments/assets/b378c085-6711-456b-a0b6-2910f70d176b)
