### PR TITLE
fix: honor trailing-slash directory patterns in gitignore (#21)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   ],
   "preview": false,
   "pricing": "Free",
-  
+  "activationEvents": [],
   "main": "./out/extension.js",
   "activationEvents": [],
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   "pricing": "Free",
   "activationEvents": [],
   "main": "./out/extension.js",
-  "activationEvents": [],
   "contributes": {
     "commands": [
       {

--- a/src/utils/fileProcessor.ts
+++ b/src/utils/fileProcessor.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { isBinaryFile } from 'isbinaryfile';
 import { FileContent, ProcessFileOptions } from '../types';
+import { IgnoreUtils } from './ignoreUtils';
 
 export class FileProcessor {
     
@@ -13,9 +14,8 @@ export class FileProcessor {
     ): Promise<FileContent | null> {
         try {
             const relativePath = path.relative(rootPath, filePath);
-            const relativePosix = relativePath.split(path.sep).join('/');
-            
-            if (ig.ignores(relativePosix)) {
+
+            if (IgnoreUtils.isIgnored(ig, relativePath, false)) {
                 return null;
             }
             
@@ -133,8 +133,7 @@ export class FileProcessor {
             // Check if the directory itself should be ignored before reading its contents
             // This prevents unnecessary file system operations on large ignored directories
             const relativeDirPath = path.relative(rootPath, dirPath);
-            const relativeDirPosix = relativeDirPath.split(path.sep).join('/');
-            if (relativeDirPath && ig.ignores(relativeDirPosix)) {
+            if (IgnoreUtils.isIgnored(ig, relativeDirPath, true)) {
                 return results;
             }
             

--- a/src/utils/ignoreUtils.ts
+++ b/src/utils/ignoreUtils.ts
@@ -16,6 +16,16 @@ export class IgnoreUtils {
         return ig;
     }
 
+    // Per gitignore spec, patterns ending in `/` (e.g. `build/`) match directories only.
+    // The `ignore` lib needs a trailing slash on the checked path to recognize it as a dir.
+    public static isIgnored(ig: any, relativePath: string, isDirectory: boolean): boolean {
+        if (!relativePath) {
+            return false;
+        }
+        const posix = relativePath.split(path.sep).join('/');
+        return ig.ignores(isDirectory ? posix + '/' : posix);
+    }
+
     public static async addGitIgnoreRules(rootPath: string, ig: any): Promise<void> {
         try {
             const gitIgnorePath = path.join(rootPath, '.gitignore');

--- a/src/utils/projectTree.ts
+++ b/src/utils/projectTree.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { IgnoreUtils } from './ignoreUtils';
 
 export class ProjectTreeGenerator {
     
@@ -27,8 +28,7 @@ export class ProjectTreeGenerator {
             // This optimization prevents reading large ignored directories like node_modules
             if (currentDepth > 0) {
                 const relativePath = path.relative(rootPath, dir);
-                const relativePathPosix = relativePath.split(path.sep).join('/');
-                if (relativePath && ig.ignores(relativePathPosix)) {
+                if (IgnoreUtils.isIgnored(ig, relativePath, true)) {
                     return '';
                 }
                 if (isExcludedByAbsolutePath(dir)) {
@@ -41,13 +41,13 @@ export class ProjectTreeGenerator {
 
             for (const entry of entries) {
                 const filePath = path.join(dir, entry.name);
-                const rootRelative = path.relative(rootPath, filePath).split(path.sep).join('/');
+                const rootRelative = path.relative(rootPath, filePath);
 
                 let isIgnored = false;
                 let isExcludedByPath = false;
 
                 try {
-                    isIgnored = ig.ignores(rootRelative);
+                    isIgnored = IgnoreUtils.isIgnored(ig, rootRelative, entry.isDirectory());
                 } catch (error) {
                     console.error(`Error checking ignore pattern for ${rootRelative}: ${error}`);
                     isIgnored = false;

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -493,6 +493,46 @@ suite('Copy4AI Extension Test Suite', () => {
             assert.strictEqual(isExcludedByAbsolutePath(filePath3), true, 'src/config/settings.json should be excluded');
         });
         
+        test('Should respect trailing-slash directory patterns (issue #21)', () => {
+            // Patterns ending with `/` (e.g. `build/`) should match directories.
+            // The `ignore` library requires the checked path to end with `/` for these to match.
+            // IgnoreUtils.isIgnored handles this when isDirectory=true is passed.
+            const ig = IgnoreUtils.createIgnoreInstance(['src-tauri/icons/', 'build/', 'dist/']);
+
+            // Directory checks: should be excluded
+            assert.strictEqual(IgnoreUtils.isIgnored(ig, path.join('src-tauri', 'icons'), true), true,
+                'src-tauri/icons directory should be ignored by `src-tauri/icons/` pattern');
+            assert.strictEqual(IgnoreUtils.isIgnored(ig, 'build', true), true,
+                'build directory should be ignored by `build/` pattern');
+            assert.strictEqual(IgnoreUtils.isIgnored(ig, path.join('packages', 'app', 'dist'), true), true,
+                'nested dist directory should be ignored (unanchored pattern)');
+
+            // Files inside the directory should also be excluded
+            assert.strictEqual(IgnoreUtils.isIgnored(ig, path.join('src-tauri', 'icons', 'logo.png'), false), true,
+                'file inside src-tauri/icons should be ignored');
+
+            // Same-named file (not dir) should NOT be ignored — `foo/` only matches directories
+            assert.strictEqual(IgnoreUtils.isIgnored(ig, 'build', false), false,
+                'a file named `build` should not match the `build/` directory-only pattern');
+
+            // Similarly-named directories should not match
+            assert.strictEqual(IgnoreUtils.isIgnored(ig, 'build-tools', true), false,
+                'build-tools should not match `build/` pattern');
+        });
+
+        test('Should treat patterns without trailing slash as matching both files and dirs', () => {
+            const ig = IgnoreUtils.createIgnoreInstance(['node_modules', '*.log']);
+
+            assert.strictEqual(IgnoreUtils.isIgnored(ig, 'node_modules', true), true,
+                'node_modules dir should be ignored');
+            assert.strictEqual(IgnoreUtils.isIgnored(ig, 'node_modules', false), true,
+                'file named node_modules should also be ignored (pattern has no trailing slash)');
+            assert.strictEqual(IgnoreUtils.isIgnored(ig, 'app.log', false), true,
+                '*.log file should be ignored');
+            assert.strictEqual(IgnoreUtils.isIgnored(ig, '', true), false,
+                'empty relative path should not be ignored');
+        });
+
         test('Should handle combined exclusion patterns correctly', () => {
             // Create a mock workspace path with platform-independent path
             const workspacePath = path.resolve('/mock/workspace');


### PR DESCRIPTION
The `ignore` lib follows gitignore spec strictly: patterns ending in `/` (like `build/`) only match directories, and it figures out "this is a directory" by whether the *checked path* has a trailing slash. We were calling `path.relative(...)` (which strips the slash) and passing the bare string to `ig.ignores()` even for known directories. So `ig.ignores('build')` against pattern `build/` returned false and the dir wasn't skipped.

Files inside still got filtered (their full paths matched the pattern), but we'd recurse into the ignored dir for nothing and the empty dir name leaked into the project tree.

Fix: new helper `IgnoreUtils.isIgnored(ig, relativePath, isDirectory)` that appends `/` when the path is a known dir. The four `ig.ignores()` call sites in `projectTree.ts` and `fileProcessor.ts` go through it now. Two regression tests added.

Closes #21